### PR TITLE
Add support for Modbus Must protocol

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 platform = espressif8266@4.2.1
 framework = arduino
 monitor_speed = 115200
-custom_prog_version = 1.1.7
+custom_prog_version = 1.2.0
 build_flags = 
 	-DVERSION=${this.custom_prog_version}
 	-DPIO_SRC_NAM="Solar2MQTT"
@@ -30,6 +30,7 @@ lib_deps =
 	https://github.com/dok-net/ghostl
 	robtillaart/CRC@^1.0.1
 	asjdf/WebSerialLite@^2.2.0
+	4-20ma/ModbusMaster@^2.0.1
 
 [env:d1_mini]
 board = d1_mini

--- a/src/PI_Serial/PI_Serial.cpp
+++ b/src/PI_Serial/PI_Serial.cpp
@@ -182,7 +182,6 @@ void PI_Serial::autoDetect() // function for autodetect the inverter type
         this->my_serialIntf->end();
     }
     this->my_serialIntf->end();
-    writeLog("----------------- End Autodetect -----------------");
     if (protocol == NoD)
     {
         modbus = new MODBUS(this->my_serialIntf);
@@ -190,7 +189,8 @@ void PI_Serial::autoDetect() // function for autodetect the inverter type
         if (modbus->autoDetect()){
             protocol = MODBUS_MUST;
         }
-    }
+    } 
+    writeLog("----------------- End Autodetect -----------------");
 }
 
 bool PI_Serial::sendCustomCommand()

--- a/src/PI_Serial/PI_Serial.h
+++ b/src/PI_Serial/PI_Serial.h
@@ -3,6 +3,7 @@
 #define PI_SERIAL_H
 
 #include <ArduinoJson.h>
+#include <modbus/modbus.h>
 extern JsonObject deviceJson;
 extern JsonObject staticData;
 extern JsonObject liveData;
@@ -85,9 +86,7 @@ public:
     void callback(std::function<void()> func);
     std::function<void()> requestCallback;
 
-private:
-    unsigned int soft_tx;
-    unsigned int soft_rx;
+private: 
     unsigned int serialIntfBaud;
 
     unsigned long previousTime = 0;
@@ -99,11 +98,14 @@ private:
     byte qexCounter = 0;
     
     String customCommandBuffer;
+
+    MODBUS *modbus;
     enum protocolType
     {
         NoD,
         PI18,
         PI30,
+        MODBUS_MUST
     };
 
     /**
@@ -148,6 +150,8 @@ private:
     bool PIXX_QPIRI();
     bool PIXX_QPI();
     bool PIXX_QMN();
+
+    bool isModbus();
 };
 
 #endif

--- a/src/PI_Serial/PI_Serial.h
+++ b/src/PI_Serial/PI_Serial.h
@@ -86,6 +86,14 @@ public:
     void callback(std::function<void()> func);
     std::function<void()> requestCallback;
 
+    enum protocolType
+    {
+        NoD,
+        PI18,
+        PI30,
+        MODBUS_MUST
+    };
+
 private: 
     unsigned int serialIntfBaud;
 
@@ -100,13 +108,6 @@ private:
     String customCommandBuffer;
 
     MODBUS *modbus;
-    enum protocolType
-    {
-        NoD,
-        PI18,
-        PI30,
-        MODBUS_MUST
-    };
 
     /**
      * @brief get the crc from a string

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,7 +451,7 @@ void loop()
   if (restartNow && millis() >= (RestartTimer + 500))
   {
     ESP.restart();
-  }
+  } 
   notificationLED(); // notification LED routine
 }
 

--- a/src/modbus/modbus.cpp
+++ b/src/modbus/modbus.cpp
@@ -1,0 +1,379 @@
+// #define isDEBUG
+#include "ArduinoJson.h"
+#include "modbus.h"
+
+extern void writeLog(const char *format, ...);
+//----------------------------------------------------------------------
+//  Public Functions
+//----------------------------------------------------------------------
+
+MODBUS::MODBUS(SoftwareSerial *port)
+{
+    this->my_serialIntf = port;
+}
+
+void MODBUS::preTransmission()
+{
+    digitalWrite(RS485_DIR_PIN, 1);
+}
+
+void MODBUS::postTransmission()
+{
+    digitalWrite(RS485_DIR_PIN, 0);
+}
+
+bool MODBUS::Init()
+{
+    // Null check the serial interface
+    if (this->my_serialIntf == NULL)
+    {
+        writeLog("No serial specificed!");
+        return false;
+    }
+    this->my_serialIntf->setTimeout(500);
+    this->my_serialIntf->begin(RS485_BAUDRATE, SWSERIAL_8N1);
+
+    // Init in receive mode
+    pinMode(RS485_DIR_PIN, OUTPUT);
+    this->postTransmission();
+
+    // Callbacks allow us to configure the RS485 transceiver correctly
+    mb.preTransmission(preTransmission);
+    mb.postTransmission(postTransmission);
+
+    mb.begin(INVERTER_MODBUS_ADDR, *this->my_serialIntf);
+
+    live_info = {
+        .variant = &liveData,
+        .registers = registers_live,
+        .array_size = sizeof(registers_live) / sizeof(modbus_register_t),
+        .curr_register = 0};
+
+    return true;
+}
+
+void MODBUS::loop()
+{
+    if (!device_found)
+        return; 
+    if (parseModbusToJson(live_info))
+    {
+        connectionCounter = 0;
+        requestCallback();
+    }
+    else
+    {
+        connectionCounter++;
+    }
+    connection = (connectionCounter < 10) ? true : false;
+}
+
+void MODBUS::callback(std::function<void()> func)
+{
+    requestCallback = func;
+}
+
+String MODBUS::requestData(String command)
+{
+
+    return "";
+}
+
+bool MODBUS::getModbusResultMsg(uint8_t result)
+{
+    String tmpstr2 = "";
+    switch (result)
+    {
+    case mb.ku8MBSuccess:
+        return true;
+        break;
+    case mb.ku8MBIllegalFunction:
+        tmpstr2 = "Illegal Function";
+        break;
+    case mb.ku8MBIllegalDataAddress:
+        tmpstr2 = "Illegal Data Address";
+        break;
+    case mb.ku8MBIllegalDataValue:
+        tmpstr2 = "Illegal Data Value";
+        break;
+    case mb.ku8MBSlaveDeviceFailure:
+        tmpstr2 = "Slave Device Failure";
+        break;
+    case mb.ku8MBInvalidSlaveID:
+        tmpstr2 = "Invalid Slave ID";
+        break;
+    case mb.ku8MBInvalidFunction:
+        tmpstr2 = "Invalid Function";
+        break;
+    case mb.ku8MBResponseTimedOut:
+        tmpstr2 = "Response Timed Out";
+        break;
+    case mb.ku8MBInvalidCRC:
+        tmpstr2 = "Invalid CRC";
+        break;
+    default:
+        tmpstr2 = "Unknown error: " + String(result);
+        break;
+    }
+    writeLog("%s", tmpstr2.c_str());
+    return false;
+}
+
+bool MODBUS::getModbusValue(uint16_t register_id, modbus_entity_t modbus_entity, uint16_t *value_ptr)
+{
+    // writeLog("Requesting data");
+    for (uint8_t i = 0; i < MODBUS_RETRIES; ++i)
+    {
+        if (MODBUS_RETRIES > 1)
+        {
+            writeLog("Trial %d/%d", i + 1, MODBUS_RETRIES);
+        }
+        if (modbus_entity == MODBUS_TYPE_HOLDING)
+        {
+            uint8_t result = mb.readHoldingRegisters(register_id, 1);
+            if (getModbusResultMsg(result))
+            {
+                *value_ptr = mb.getResponseBuffer(0);
+                return true;
+            }
+        }
+        else
+        {
+            writeLog("Unsupported Modbus entity type");
+            value_ptr = nullptr;
+            return false;
+        }
+    }
+    // Time-out
+    writeLog("Time-out");
+    value_ptr = nullptr;
+    return false;
+}
+
+String MODBUS::toBinary(uint16_t input)
+{
+    String output;
+    while (input != 0)
+    {
+        output = (input % 2 == 0 ? "0" : "1") + output;
+        input /= 2;
+    }
+    return output;
+}
+
+bool MODBUS::decodeDiematicDecimal(uint16_t int_input, int8_t decimals, float *value_ptr)
+{
+    if (int_input == 65535)
+    {
+        value_ptr = nullptr;
+        return false;
+    }
+    else
+    {
+        uint16_t masked_input = int_input & 0x7FFF;
+        float output = static_cast<float>(masked_input);
+        if (int_input >> 15 == 1)
+        {
+            output = -output;
+        }
+        *value_ptr = output / pow(10, decimals);
+        return true;
+    }
+}
+
+bool MODBUS::readModbusRegisterToJson(const modbus_register_t *reg, JsonObject *variant)
+{
+    // register found
+    if (reg == nullptr || variant == nullptr)
+    {
+        return false; // Return false if invalid input
+    }
+    writeLog("Register id=%d type=0x%x name=%s", reg->id, reg->type, reg->name);
+    uint16_t raw_value = 0;
+
+    float final_value;
+    if (getModbusValue(reg->id, reg->modbus_entity, &raw_value))
+    {
+        // writeLog("Raw value: %s=%#06x", reg->name, raw_value);
+
+        switch (reg->type)
+        {
+        case REGISTER_TYPE_U16:
+            // writeLog("Value: %u", raw_value);
+            (*variant)[reg->name] = raw_value;
+            break;
+
+        case REGISTER_TYPE_DIEMATIC_ONE_DECIMAL:
+            if (decodeDiematicDecimal(raw_value, 1, &final_value))
+            {
+                // writeLog("Value: %.1f", final_value);
+                (*variant)[reg->name] = final_value;
+            }
+            else
+            {
+                writeLog("Invalid Diematic value");
+            }
+            break;
+
+        case REGISTER_TYPE_DIEMATIC_TWO_DECIMAL:
+            if (decodeDiematicDecimal(raw_value, 2, &final_value))
+            {
+                // writeLog("Value: %.1f", final_value);
+                (*variant)[reg->name] = final_value;
+            }
+            else
+            {
+                writeLog("Invalid Diematic value");
+            }
+            break;
+        case REGISTER_TYPE_BITFIELD:
+
+            for (uint8_t j = 0; j < 16; ++j)
+            {
+                const char *bit_varname = reg->optional_param.bitfield[j];
+                if (bit_varname == nullptr)
+                {
+                    writeLog("[bit%02d] end of bitfield reached", j);
+                    break;
+                }
+                const uint8_t bit_value = raw_value >> j & 1;
+                writeLog(" [bit%02d] %s=%d", j, bit_varname, bit_value);
+                (*variant)[bit_varname] = bit_value;
+            }
+            break;
+
+        case REGISTER_TYPE_CUSTOM_VAL_NAME:
+        {
+            bool isfound = false;
+            for (uint8_t j = 0; j < 16; ++j)
+            {
+                const char *bit_varname = reg->optional_param.bitfield[j];
+                if (bit_varname == nullptr)
+                {
+                    writeLog("bitfield[%d] is null", j);
+                    break;
+                }
+                if (j == raw_value)
+                {
+                    // writeLog("Match found, value: %s", bit_varname);
+                    (*variant)[reg->name] = bit_varname;
+                    isfound = true;
+                    break;
+                }
+            }
+            if (!isfound)
+            {
+                writeLog("CUSTOM_VAL_NAME not found for raw_value=%d", raw_value);
+            }
+            break;
+        }
+        case REGISTER_TYPE_ASCII:
+        {
+            String out = "";
+            char high_byte = (raw_value >> 8) & 0xFF;
+            char low_byte = raw_value & 0xFF;
+
+            out += high_byte;
+            out += low_byte;
+            (*variant)[reg->name] = out;
+            break;
+        }
+        case REGISTER_TYPE_DEBUG:
+
+            writeLog("Raw DEBUG value: %s=%#06x %s", reg->name, raw_value, toBinary(raw_value).c_str());
+            break;
+
+        default:
+            // Unsupported type
+
+            writeLog("Unsupported register type");
+            break;
+        }
+    }
+    else
+    {
+        writeLog("Request failed!");
+        return false;
+    }
+    writeLog("Request OK!");
+    return true;
+}
+
+bool MODBUS::parseModbusToJson(modbus_register_info_t &register_info)
+{
+    // writeLog("Parsing Modbus registers");
+    if (register_info.curr_register >= register_info.array_size)
+    {
+        register_info.curr_register = 0;
+    }
+    writeLog("Registers size %d", register_info.array_size); 
+    previousTime = millis();
+    for (; register_info.curr_register <= register_info.array_size - 1; register_info.curr_register++)
+    {
+        writeLog("curr %d", register_info.curr_register);
+        bool ret_val = readModbusRegisterToJson(&register_info.registers[register_info.curr_register], register_info.variant);
+
+        if (!ret_val)
+        {
+            return false;
+        }
+
+        if (millis() - previousTime > cmdDelayTime) //limit execution time
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+//----------------------------------------------------------------------
+// Private Functions
+//----------------------------------------------------------------------
+bool MODBUS::autoDetect() // function for autodetect the inverter type
+{
+    String modelName = retrieveModel();
+    if (modelName)
+    {
+        writeLog("<Autodetect> Found Modbus device: %s", modelName);
+        staticData["Device_Model"] = modelName;
+        device_found = true;
+        return true;
+    }
+
+    return false;
+}
+
+String MODBUS::retrieveModel()
+{
+    bool found = false;
+    String model = "";
+    DynamicJsonDocument doc(256);
+    JsonObject jsonObj = doc.to<JsonObject>(); // Create and get JsonObject
+    modbus_register_info_t model_info = {
+        .variant = &jsonObj,
+        .registers = registers_device_model,
+        .array_size = sizeof(registers_device_model) / sizeof(modbus_register_t),
+        .curr_register = 0};
+
+    for (size_t i = 0; i < 6; i++)
+    {
+        if (parseModbusToJson(model_info))
+        {
+            found = true;
+            break;
+        }
+        delay(100);
+    }
+
+    if (found)
+    {
+        const char *modelHigh = doc[DEVICE_MODEL_HIGH];
+        int modelLow = doc[DEVICE_MODEL_LOW];
+        String jsonString;
+        serializeJson(doc, jsonString);
+        writeLog("JSON MODEL: %s", jsonString);
+        return String(modelHigh) + String(modelLow);
+    }
+    return model;
+}

--- a/src/modbus/modbus.cpp
+++ b/src/modbus/modbus.cpp
@@ -333,7 +333,7 @@ bool MODBUS::parseModbusToJson(modbus_register_info_t &register_info)
     previousTime = millis();
     while (register_info.curr_register <= register_info.array_size)
     {
-       bool ret_val = readModbusRegisterToJson(&register_info.registers[register_info.curr_register], register_info.variant);
+        bool ret_val = readModbusRegisterToJson(&register_info.registers[register_info.curr_register], register_info.variant);
         register_info.curr_register++;
         if (!ret_val)
         {
@@ -354,15 +354,15 @@ bool MODBUS::parseModbusToJson(modbus_register_info_t &register_info)
 //----------------------------------------------------------------------
 bool MODBUS::autoDetect() // function for autodetect the inverter type
 {
+    writeLog("Try Autodetect Modbus device");
+    device_found = false;
     String modelName = retrieveModel();
     if (!modelName.isEmpty())
     {
         writeLog("<Autodetect> Found Modbus device: %s", modelName);
         staticData["Device_Model"] = modelName;
-        device_found = true;
-        return true;
     }
-    return false;
+    return device_found;
 }
 
 String MODBUS::retrieveModel()
@@ -377,7 +377,7 @@ String MODBUS::retrieveModel()
         .array_size = sizeof(registers_device_model) / sizeof(modbus_register_t),
         .curr_register = 0};
 
-    for (size_t i = 0; i < 6; i++)
+    for (size_t i = 0; i < model_info.array_size * 2; i++)
     {
         if (parseModbusToJson(model_info))
         {
@@ -391,9 +391,6 @@ String MODBUS::retrieveModel()
     {
         const char *modelHigh = doc[DEVICE_MODEL_HIGH];
         int modelLow = doc[DEVICE_MODEL_LOW];
-        String jsonString;
-        serializeJson(doc, jsonString);
-        writeLog("JSON MODEL: %s", jsonString);
         return String(modelHigh) + String(modelLow);
     }
     return model;

--- a/src/modbus/modbus.cpp
+++ b/src/modbus/modbus.cpp
@@ -148,7 +148,7 @@ bool MODBUS::getModbusValue(uint16_t register_id, modbus_entity_t modbus_entity,
     {
         if (MODBUS_RETRIES > 1)
         {
-            // writeLog("Trial %d/%d", i + 1, MODBUS_RETRIES);
+            writeLog("Trial %d/%d", i + 1, MODBUS_RETRIES);
         }
         if (modbus_entity == MODBUS_TYPE_HOLDING)
         {
@@ -331,10 +331,10 @@ bool MODBUS::parseModbusToJson(modbus_register_info_t &register_info)
     }
     // writeLog("Registers size %d", register_info.array_size);
     previousTime = millis();
-    for (; register_info.curr_register <= register_info.array_size - 1; register_info.curr_register++)
+    while (register_info.curr_register <= register_info.array_size)
     {
-        bool ret_val = readModbusRegisterToJson(&register_info.registers[register_info.curr_register], register_info.variant);
-
+       bool ret_val = readModbusRegisterToJson(&register_info.registers[register_info.curr_register], register_info.variant);
+        register_info.curr_register++;
         if (!ret_val)
         {
             return false;
@@ -355,14 +355,13 @@ bool MODBUS::parseModbusToJson(modbus_register_info_t &register_info)
 bool MODBUS::autoDetect() // function for autodetect the inverter type
 {
     String modelName = retrieveModel();
-    if (modelName)
+    if (!modelName.isEmpty())
     {
         writeLog("<Autodetect> Found Modbus device: %s", modelName);
         staticData["Device_Model"] = modelName;
         device_found = true;
         return true;
     }
-
     return false;
 }
 

--- a/src/modbus/modbus.h
+++ b/src/modbus/modbus.h
@@ -34,6 +34,7 @@ public:
     bool requestStaticData = true;
     bool connection = false;
     modbus_register_info_t live_info;
+    modbus_register_info_t static_info;
     MODBUS(SoftwareSerial *port);
 
     /**

--- a/src/modbus/modbus.h
+++ b/src/modbus/modbus.h
@@ -9,7 +9,11 @@ extern JsonObject deviceJson;
 extern JsonObject staticData;
 extern JsonObject liveData;
 
-#define RS485_DIR_PIN D5
+ 
+#define RS485_DIR_PIN 14 //D5
+#define RS485_ESP01_DIR_PIN 0 
+
+
 #define RS485_BAUDRATE 19200
 
 #define INVERTER_MODBUS_ADDR 4
@@ -64,11 +68,11 @@ public:
     String requestData(String command);
 
 private:
-    bool device_found = false;
-    unsigned int soft_tx;
-    unsigned int soft_rx;
-    unsigned long previousTime = 0; 
-    unsigned long cmdDelayTime = 3000; 
+    bool device_found = false; 
+    unsigned long previousTime = 0;
+    unsigned long cmdDelayTime = 3000;
+
+
     byte requestCounter = 0;
 
     long long int connectionCounter = 0;

--- a/src/modbus/modbus.h
+++ b/src/modbus/modbus.h
@@ -1,0 +1,105 @@
+#include "SoftwareSerial.h"
+#ifndef MODBUS_H
+#define MODBUS_H
+
+#include <ArduinoJson.h>
+#include <ModbusMaster.h>
+#include "modbus_registers.h"
+extern JsonObject deviceJson;
+extern JsonObject staticData;
+extern JsonObject liveData;
+
+#define RS485_DIR_PIN D5
+#define RS485_BAUDRATE 19200
+
+#define INVERTER_MODBUS_ADDR 4
+
+#define MODBUS_RETRIES 2
+
+typedef struct
+{
+    JsonObject *variant;
+    const modbus_register_t *registers;
+    uint8_t array_size;
+    uint8_t curr_register;
+} modbus_register_info_t;
+
+class MODBUS
+{
+public:
+    bool requestStaticData = true;
+    bool connection = false;
+    modbus_register_info_t live_info;
+    MODBUS(SoftwareSerial *port);
+
+    /**
+     * @brief Initializes this driver
+     * @details Configures the serial peripheral and pre-loads the transmit buffer with command-independent bytes
+     */
+    bool Init();
+
+    /**
+     * @brief Updating the Data from the inverter
+     */
+    void loop();
+
+    /**
+     * @brief Send custom command to the device
+     */
+    bool sendCommand(String command);
+
+    /**
+     * @brief callback function
+     *
+     */
+    void callback(std::function<void()> func);
+    std::function<void()> requestCallback;
+    bool readModbusRegisterToJson(const modbus_register_t *reg, JsonObject *variant);
+    bool parseModbusToJson(modbus_register_info_t &register_info);
+    bool autoDetect();
+    /**
+     * @brief Sends a complete packet with the specified command
+     * @details sends the command over the specified serial connection
+     */
+    String requestData(String command);
+
+private:
+    bool device_found = false;
+    unsigned int soft_tx;
+    unsigned int soft_rx;
+    unsigned long previousTime = 0; 
+    unsigned long cmdDelayTime = 3000; 
+    byte requestCounter = 0;
+
+    long long int connectionCounter = 0;
+
+    byte qexCounter = 0;
+
+    static void preTransmission();
+    static void postTransmission();
+    String toBinary(uint16_t input);
+    bool decodeDiematicDecimal(uint16_t int_input, int8_t decimals, float *value_ptr);
+    bool getModbusResultMsg(uint8_t result);
+    bool getModbusValue(uint16_t register_id, modbus_entity_t modbus_entity, uint16_t *value_ptr);
+    /**
+     * @brief get the crc from a string
+     */
+    uint16_t getCRC(String data);
+
+    /**
+     * @brief get the crc from a string
+     */
+    byte getCHK(String data);
+
+    String retrieveModel();
+
+    /**
+     * @brief Serial interface used for communication
+     * @details This is set in the constructor
+     */
+    SoftwareSerial *my_serialIntf;
+
+    ModbusMaster mb;
+};
+
+#endif

--- a/src/modbus/modbus_registers.h
+++ b/src/modbus/modbus_registers.h
@@ -1,0 +1,81 @@
+#ifndef SRC_MODBUS_REGISTERS_H_
+#define SRC_MODBUS_REGISTERS_H_
+#include "Arduino.h"
+
+typedef enum
+{
+    MODBUS_TYPE_HOLDING = 0x00, /*!< Modbus Holding register. */ 
+    //    MODBUS_TYPE_INPUT,                  /*!< Modbus Input register. */
+    //    MODBUS_TYPE_COIL,                   /*!< Modbus Coils. */
+    //    MODBUS_TYPE_DISCRETE,               /*!< Modbus Discrete bits. */
+    //    MODBUS_TYPE_COUNT,
+    //    MODBUS_TYPE_UNKNOWN = 0xFF
+} modbus_entity_t;
+
+typedef enum
+{
+    //    REGISTER_TYPE_U8 = 0x00,                   /*!< Unsigned 8 */
+    REGISTER_TYPE_U16 = 0x01,   /*!< Unsigned 16 */
+                                //    REGISTER_TYPE_U32 = 0x02,                  /*!< Unsigned 32 */
+                                //    REGISTER_TYPE_FLOAT = 0x03,                /*!< Float type */
+    REGISTER_TYPE_ASCII = 0x04, /*!< ASCII type */
+    REGISTER_TYPE_DIEMATIC_ONE_DECIMAL = 0x05,
+    REGISTER_TYPE_DIEMATIC_TWO_DECIMAL = 0x06,
+    REGISTER_TYPE_BITFIELD = 0x07,
+    REGISTER_TYPE_DEBUG = 0x08,
+    REGISTER_TYPE_CUSTOM_VAL_NAME = 0x09,
+} register_type_t;
+
+typedef union
+{
+    const char *bitfield[16];
+} optional_param_t;
+
+typedef struct
+{
+    uint16_t id;
+    modbus_entity_t modbus_entity; /*!< Type of modbus parameter */
+    register_type_t type;          /*!< Float, U8, U16, U32, ASCII, etc. */
+    const char *name;
+    optional_param_t optional_param;
+} modbus_register_t;
+
+const modbus_register_t registers_live[] = {
+
+    {25201, MODBUS_TYPE_HOLDING, REGISTER_TYPE_CUSTOM_VAL_NAME, "Inverter_Operation_Mode", {.bitfield = {
+                                                                                                "Power On",
+                                                                                                "Self Test",
+                                                                                                "OffGrid",
+                                                                                                "GridTie",
+                                                                                                "ByPass",
+                                                                                                "Stop",
+                                                                                                "GridCharging",
+                                                                                            }}},
+
+    {25205, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "Battery_Voltage"},
+    {25274, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "Battery_Load"},
+    {25207, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "AC_in_Voltage"},
+    {25226, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_TWO_DECIMAL, "AC_in_Frequenz"},
+
+    {25206, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "AC_out_Voltage"},
+    {25225, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_TWO_DECIMAL, "AC_out_Frequenz"},
+
+    {25208, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "Inverter_Bus_Voltage"},
+    {25216, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "Output_load_percent"},
+    {15205, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "PV_Input_Voltage"},
+    {15208, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "PV_Charging_Power"},
+    {15207, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "PV_Input_Current"},
+    {25233, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "Inverter_Bus_Temperature"},
+    {25234, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "Transformer_temperature"},
+    {15209, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "MPPT1_Charger_Temperature"},
+};
+
+#define DEVICE_MODEL_HIGH "Device_Model_Hight"
+#define DEVICE_MODEL_LOW "Device_Model_Low"
+
+const modbus_register_t registers_device_model[] = { 
+    {20000, MODBUS_TYPE_HOLDING, REGISTER_TYPE_ASCII, "Device_Model_Hight"},
+    {20001, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "Device_Model_Low"}
+};
+
+#endif // SRC_MODBUS_REGISTERS_H_

--- a/src/modbus/modbus_registers.h
+++ b/src/modbus/modbus_registers.h
@@ -70,6 +70,21 @@ const modbus_register_t registers_live[] = {
     {15209, MODBUS_TYPE_HOLDING, REGISTER_TYPE_U16, "MPPT1_Charger_Temperature"},
 };
 
+const modbus_register_t registers_static[] = {
+
+    {10110, MODBUS_TYPE_HOLDING, REGISTER_TYPE_CUSTOM_VAL_NAME, "Battery_type", {.bitfield = {
+                                                                                                "No choose",
+                                                                                                "User defined",
+                                                                                                "Lithium",
+                                                                                                "Sealed Lead",
+                                                                                                "AGM",
+                                                                                                "GEL",
+                                                                                                "Flooded", 
+                                                                                            }}},
+    {10103, MODBUS_TYPE_HOLDING, REGISTER_TYPE_DIEMATIC_ONE_DECIMAL, "Battery_float_voltage"},                        
+};
+
+
 #define DEVICE_MODEL_HIGH "Device_Model_Hight"
 #define DEVICE_MODEL_LOW "Device_Model_Low"
 


### PR DESCRIPTION
Tested on Must PH18-3024, also should work on all pv/ph18 series
As hardware was used wemos d1 mini  controller + MAX485 module 
Connection diagram
![modbus-must](https://github.com/user-attachments/assets/74a6bfcf-5796-4e6e-8a35-d18a5af3e99c)

The power for controller taken from USB output of the inverter  

The json data received from inverter
`{"DeviceData":{"Device_Model":"PH1800","Battery_type":"AGM","Battery_float_voltage":"27.0"},"LiveData":{"Inverter_Operation_Mode":"GridTie","Battery_Voltage":"27.5","Battery_Load":0,"AC_in_Voltage":"242.8","AC_in_Frequenz":"50.00","AC_out_Voltage":"242.6","AC_out_Frequenz":"50.01","Inverter_Bus_Voltage":"438.8","Output_load_percent":7,"PV_Input_Voltage":"105.8","PV_Charging_Power":88,"PV_Input_Current":"2.9","Inverter_Bus_Temperature":45,"Transformer_temperature":46,"MPPT1_Charger_Temperature":37}`
