### PR TITLE
Add support of one Dallas DS18x20 temperature sensor

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,12 +30,14 @@ lib_deps =
 	plerup/EspSoftwareSerial @ ^8.2.0
 	https://github.com/dok-net/ghostl
 	robtillaart/CRC@^1.0.1
+	milesburton/DallasTemperature @ ^3.11.0
 
 [env:d1_mini]
 board = d1_mini
 board_build.ldscript = eagle.flash.4m.ld
 build_flags = ${env.build_flags}
 custom_hardwareserial = false
+onewire_bus = 14
 monitor_filters = esp8266_exception_decoder, default, time, printable, colorize
 upload_speed = 921600
 
@@ -43,6 +45,7 @@ upload_speed = 921600
 board = esp12e
 board_build.ldscript = eagle.flash.4m.ld
 custom_hardwareserial = true
+onewire_bus = false
 build_flags = ${env.build_flags}
 custom_prog_version = ${env.custom_prog_version}_Dongle
 monitor_filters = esp8266_exception_decoder, default, time, printable, colorize
@@ -52,6 +55,7 @@ upload_speed = 921600
 board = esp01_1m
 board_build.ldscript = eagle.flash.1m.ld
 custom_hardwareserial = true
+onewire_bus = false
 build_flags = ${env.build_flags}
 custom_prog_version = ${env.custom_prog_version}_ESP01
 monitor_filters = esp8266_exception_decoder, default, time, printable, colorize

--- a/src/OneWire/DSTemp.cpp
+++ b/src/OneWire/DSTemp.cpp
@@ -1,0 +1,55 @@
+#ifdef ONE_WIRE_BUS
+
+#include "DSTemp.h"
+
+extern void writeLog(const char *format, ...);
+
+DSTemp::DSTemp() {
+    oneWire = OneWire(ONE_WIRE_BUS);
+    sensors = DallasTemperature(&oneWire);
+}
+
+void DSTemp::init() {
+    sensors.begin();
+    if (sensors.getDeviceCount() > 0)
+    {
+        if (!sensors.getAddress(address, 0))
+        {
+            writeLog("Dallas temperature sensor isn't found");
+            return;
+        }
+        sensors.setResolution(address, 9);
+
+        isSensorExist = true;
+        lastUpdateTime = 0;
+
+        writeLog("Dallas temperature sensor found");
+    }
+    isInit = true;
+}
+
+void DSTemp::loop() {
+    if (!isInit)
+    {
+        init();
+    }
+    if (isInit && isSensorExist)
+    {
+        if (millis() - lastUpdateTime > 5000)
+        {
+            lastUpdateTime = millis();
+            sensors.requestTemperatures();
+            float tempC = sensors.getTempC(address);
+            if (tempC == DEVICE_DISCONNECTED_C)
+            {
+                writeLog("Error: Could not read temperature data");
+                return;
+            }
+            char tmp[8];
+            sprintf(tmp, "%.1f", tempC);
+            liveData["External_Temperature"] = tmp;
+        }
+    }
+}
+
+#endif

--- a/src/OneWire/DSTemp.h
+++ b/src/OneWire/DSTemp.h
@@ -1,0 +1,26 @@
+#ifndef DALLAS_TEMPERATURE_H
+#define DALLAS_TEMPERATURE_H
+#ifdef ONE_WIRE_BUS
+
+#include <OneWire.h>
+#include <DallasTemperature.h>
+#include <ArduinoJson.h>
+
+extern JsonObject liveData;
+
+class DSTemp {
+private:
+    OneWire oneWire;
+    DallasTemperature sensors;
+    DeviceAddress address{};
+    bool isInit = false;
+    bool isSensorExist = false;
+    uint32_t lastUpdateTime = 0;
+    void init();
+public:
+    DSTemp();
+    void loop();
+};
+
+#endif
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,11 @@ AsyncWebSocketClient *wsClient;
 DNSServer dns;
 Settings settings;
 
+#ifdef ONE_WIRE_BUS
+#include "OneWire/DSTemp.h"
+DSTemp dsTemp;
+#endif
+
 #include "status-LED.h"
 
 // new importetd
@@ -437,6 +442,9 @@ void loop()
       }
       ws.cleanupClients(); // clean unused client connections
       mppClient.loop(); // Call the PI Serial Library loop
+#ifdef ONE_WIRE_BUS
+      dsTemp.loop();
+#endif
       mqttclient.loop();
       if ((haDiscTrigger || settings.data.haDiscovery) && measureJson(Json) > jsonSize)
       {

--- a/tools/pre_compile.py
+++ b/tools/pre_compile.py
@@ -10,4 +10,9 @@ if env.GetProjectOption("custom_hardwareserial") == "true":
         ("isUART_HARDWARE",  env.StringifyMacro(env.GetBuildType())),
     ])
 
+if env.GetProjectOption("onewire_bus").isnumeric():
+    env.Append(CPPDEFINES=[
+        ("ONE_WIRE_BUS",  env.GetProjectOption("onewire_bus")),
+    ])
+
 env.Replace(PROGNAME="Solar2MQTT_%s_%s" % (str(env["BOARD"]), env.GetProjectOption("custom_prog_version")))


### PR DESCRIPTION
I'm suggest a simple support of one of Dallas DS18x20 temperature sensor. 
It should be connected by classical scheme into D5 (gpio14, can be changed through platfomio.ini) of the Wemos D1 mini.
It may be useful to control the environment temperature, for example, around of the inverter.
For now it simply publish the temperature into `Device/LiveData/External_Temperature` topic.