### PR TITLE
Support of yet another variant of PI30 Q1 response

### DIFF
--- a/src/PI_Serial/Q1.h
+++ b/src/PI_Serial/Q1.h
@@ -14,6 +14,26 @@ static const char *const q1List[] = {
     "",
     "Inverter_charge_state",
 };
+static const char *const q1List2[] = {
+    // [PI30]
+    "Time_until_absorb_charge", // Time until the end of absorb charging
+    "Time_until_float_charge", // Time until the end of float charging
+    "", // SCC Flag
+    "", // AllowSccOnFlag
+    "", // ChargeAverageCurrent
+    "Tracker_temperature", // SCC PWM temperature
+    "Inverter_temperature",
+    "Battery_temperature",
+    "Transformer_temperature",
+    "", // GPIO13
+    "Fan_lock_status",
+    "",
+    "Fan_speed", // Fan PWM speed
+    "", // SCC charge power
+    "", // Parallel Warning
+    "", // Sync frequency
+    "Inverter_charge_state",
+};
 bool PI_Serial::PIXX_Q1()
 {
     if (protocol == PI30)
@@ -55,11 +75,39 @@ bool PI_Serial::PIXX_Q1()
                 if (!strs[i].isEmpty() && strcmp(q1List[i], "") != 0)
                     liveData[q1List[i]] = (int)(strs[i].toFloat() * 100 + 0.5) / 100.0;
             }
-
-            if (liveData.containsKey("Inverter_charge_state"))
+        }
+        if (commandAnswerLength == 70)
+        {
+            String strs[16];
+            // Split the string into substrings
+            int StringCount = 0;
+            while (commandAnswer.length() > 0)
             {
-                switch ((int)liveData["Inverter_charge_state"].as<unsigned int>())
+                // int index = commandAnswer.indexOf(delimiter);
+                int index = commandAnswer.indexOf(' ');
+                if (index == -1) // No space found
                 {
+                    strs[StringCount++] = commandAnswer;
+                    break;
+                }
+                else
+                {
+                    strs[StringCount++] = commandAnswer.substring(0, index);
+                    commandAnswer = commandAnswer.substring(index + 1);
+                }
+            }
+
+            for (unsigned int i = 0; i < sizeof q1List2 / sizeof q1List2[0]; i++)
+            {
+                if (!strs[i].isEmpty() && strcmp(q1List2[i], "") != 0)
+                    liveData[q1List2[i]] = (int)(strs[i].toFloat() * 100 + 0.5) / 100.0;
+            }
+        }
+
+        if (liveData.containsKey("Inverter_charge_state"))
+        {
+            switch ((int)liveData["Inverter_charge_state"].as<unsigned int>())
+            {
                 default:
                     // liveData["Inverter_charge_state"] = "no data";
                     break;
@@ -75,9 +123,9 @@ bool PI_Serial::PIXX_Q1()
                 case 13:
                     liveData["Inverter_charge_state"] = "Float";
                     break;
-                }
             }
         }
+
         return true;
     }
     else if (protocol == PI18)

--- a/src/main.h
+++ b/src/main.h
@@ -158,7 +158,7 @@ static const char *const haLiveDescriptor[][4]{
     //{"Country","earth","",""},
     //{"Device_Status","state-machine","",""},
     //{"EEPROM_Version","chip","",""},
-    //{"Fan_speed","fan","",""},
+    {"Fan_speed","fan","%",""},
     {"Fault_code","alert-outline","",""},
     {"Grid_frequency", "import", "Hz", "frequency"},
     {"Grid_voltage", "import", "V", "voltage"},


### PR DESCRIPTION
Suggested support of yet another variant of PI30 Q1 response: response with len of 70 bytes that given from `EASun ISolar SMH-II-2.2K`. Maybe it will valid for other `EASun` or other brands inverters...