### PR TITLE
Adding support of PI30 QPIRI another yet response len

### DIFF
--- a/src/PI_Serial/QPIRI.h
+++ b/src/PI_Serial/QPIRI.h
@@ -107,7 +107,7 @@ bool PI_Serial::PIXX_QPIRI()
       return false;
     }
     if (commandAnswer.length() > 80 &&
-        commandAnswer.length() < 105)
+        commandAnswer.length() <= 108)
     {
 
       byte protocolNum = 0;


### PR DESCRIPTION
My Anern AN-SCI-EVO-4200 returns the response for PI30 QPIRI with another yet response len -- 108 bytes. I've checked and it fully compatible with existed code and works fine for me.