### PR TITLE
Adding support of PI30 QFLAG

### DIFF
--- a/src/PI_Serial/PI_Serial.cpp
+++ b/src/PI_Serial/PI_Serial.cpp
@@ -9,6 +9,7 @@ CRC16 crc;
 #include "QPI.h"
 #include "QPIRI.h"
 #include "QMN.h"
+#include "QFLAG.h"
 // variable
 #include "Q1.h"
 #include "QPIGS.h"
@@ -81,6 +82,9 @@ bool PI_Serial::loop()
                         break;
                     case 2:
                         requestCounter = PIXX_QPI() ? (requestCounter + 1) : 0;
+                        break;
+                    case 3:
+                        requestCounter = PIXX_QFLAG() ? (requestCounter + 1) : 0;
                         requestCounter = 0;
                         requestStaticData = false;
                         break;
@@ -393,4 +397,15 @@ char *PI_Serial::getModeDesc(char mode) // get the char from QMOD and make reada
 bool PI_Serial::isModbus()
 {
     return protocol == MODBUS_MUST;
+}
+
+bool PI_Serial::checkQFLAG(const String& flags, char symbol) {
+    bool enabled = false;
+    for (int i = 0; i < flags.length(); i++) {
+        char c = flags.charAt(i);
+        if (c == 'E') enabled = true;
+        else if (c == 'D') enabled = false;
+        else if (c == symbol) return enabled;
+    }
+    return false;
 }

--- a/src/PI_Serial/PI_Serial.h
+++ b/src/PI_Serial/PI_Serial.h
@@ -26,6 +26,7 @@ public:
             String qall;
             String qpiri;
             String qmn;
+            String qflag;
             // dynamic
             String q1;
             String qpigs;
@@ -153,8 +154,11 @@ private:
     bool PIXX_QPIRI();
     bool PIXX_QPI();
     bool PIXX_QMN();
+    bool PIXX_QFLAG();
 
     bool isModbus();
+
+    static bool checkQFLAG(const String& flags, char symbol);
 };
 
 #endif

--- a/src/PI_Serial/QFLAG.h
+++ b/src/PI_Serial/QFLAG.h
@@ -1,0 +1,38 @@
+bool PI_Serial::PIXX_QFLAG()
+{
+    if (protocol == PI30)
+    {
+        String commandAnswer = this->requestData("QFLAG");
+        get.raw.qflag = commandAnswer;
+        byte commandAnswerLength = commandAnswer.length();
+        if (commandAnswer == "NAK")
+        {
+            return true;
+        }
+        if (commandAnswer == "ERCRC")
+        {
+            return false;
+        }
+        if (commandAnswerLength == 11)
+        {
+            staticData["Buzzer_Enabled"] = checkQFLAG(commandAnswer, 'a');
+            staticData["Overload_bypass_Enabled"] = checkQFLAG(commandAnswer, 'b');
+            staticData["Power_saving_Enabled"] = checkQFLAG(commandAnswer, 'j');
+            staticData["LCD_reset_to_default_Enabled"] = checkQFLAG(commandAnswer, 'k');
+            staticData["Overload_restart_Enabled"] = checkQFLAG(commandAnswer, 'u');
+            staticData["Over_temperature_restart_Enabled"] = checkQFLAG(commandAnswer, 'v');
+            staticData["LCD_backlight_Enabled"] = checkQFLAG(commandAnswer, 'x');
+            staticData["Primary_source_interrupt_alarm_Enabled"] = checkQFLAG(commandAnswer, 'y');
+            staticData["Record_fault_code_Enabled"] = checkQFLAG(commandAnswer, 'z');
+        }
+        return true;
+    }
+    else if (protocol == NoD)
+    {
+        return false;
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -640,6 +640,7 @@ bool sendtoMQTT()
     mqttclient.publish(topicBuilder(buff, "RAW/QALL"), (mppClient.get.raw.qall).c_str());
     mqttclient.publish(topicBuilder(buff, "RAW/QMN"), (mppClient.get.raw.qmn).c_str());
     mqttclient.publish(topicBuilder(buff, "RAW/QPIWS"), (mppClient.get.raw.qpiws).c_str());
+    mqttclient.publish(topicBuilder(buff, "RAW/QFLAG"), (mppClient.get.raw.qflag).c_str());
   }
   else
   {

--- a/src/main.h
+++ b/src/main.h
@@ -121,7 +121,16 @@ static const char *const haStaticDescriptor[][4]{
     //{"PV_OK_condition_for_parallel","solar-panel","",""},
     {"PV_power_balance", "solar-panel", "", ""},
     {"Solar_power_priority", "priority-high", "", ""},
-    {"Topology", "earth", "", ""}};
+    {"Topology", "earth", "", ""},
+    {"Buzzer_Enabled", "tune-variant", "", ""},
+    {"Overload_bypass_Enabled", "tune-variant", "", ""},
+    {"Power_saving_Enabled", "tune-variant", "", ""},
+    {"LCD_reset_to_default_Enabled", "tune-variant", "", ""},
+    {"Overload_restart_Enabled", "tune-variant", "", ""},
+    {"Over_temperature_restart_Enabled", "tune-variant", "", ""},
+    {"LCD_backlight_Enabled", "tune-variant", "", ""},
+    {"Primary_source_interrupt_alarm_Enabled", "tune-variant", "", ""},
+    {"Record_fault_code_Enabled", "tune-variant", "", ""}};
 static const char *const haLiveDescriptor[][4]{
     // state_topic, icon, unit_ofmeasurement, class
     {"AC_in_Frequenz", "import", "Hz", "frequency"},


### PR DESCRIPTION
Suggested support of `PI30` `QFLAG`.
Added to `Device/DeviceData/*_Enabled` with value of `true/false` and `Device/RAW/QFLAG`. 
HA static descriptors also provided.